### PR TITLE
Sqlmodel 0.0.24

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,11 +31,13 @@ test:
   commands:
     - pip check
     # Extract the version of the built package
-    - VERSION=$(python -c 'from importlib import metadata; print(metadata.version("sqlmodel"))') # [not win]
+    - VERSION=$(python -c 'from importlib import metadata; print(metadata.version("sqlmodel"))')  # [not win]
     - echo "sqlmodel version $VERSION"  # [not win]
     # Ensure that version is not 0. (This conditional looks redundant, but YAML thinks
-    # that [...] denotes a list.)
+     # that [...] denotes a list.)
     - if [ "0" == "$VERSION" ]; then false; fi  # [not win]
+    # Windows version check
+    - python -c "from importlib import metadata; v = metadata.version('sqlmodel'); print(f'sqlmodel version {v}'); assert v != '0'"  # [win]
   requires:
     - pip
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "sqlmodel" %}
-{% set version = "0.0.8" %}
+{% set version = "0.0.24" %}
 
 
 package:
@@ -8,39 +8,26 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/sqlmodel-{{ version }}.tar.gz
-  sha256: 3371b4d1ad59d2ffd0c530582c2140b6c06b090b32af9b9c6412986d7b117036
+  sha256: cc5c7613c1a5533c9c7867e1aab2fd489a76c9e8a061984da11b4e613c182423
 
 build:
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
-  noarch: python
-  script:
-    # Unfortunately sqlmodel relies on a custom plugin called "poetry-version-plugin"
-    # which relies on the development version of poetry, which is annoying to install
-    # on conda-forge. But why install some weird plugin when we can just use a simple
-    # Bash hack? ;)
-
-    # Verify that the version is correctly set in __init__.py
-    - grep __version__ sqlmodel/__init__.py | grep {{ version }}
-    # Replace the version number in the pyproject.toml with the one we extracted
-    - sed -i "s/version = \"0\"/version = \"{{ version }}\"/" pyproject.toml
-    # Install
-    - {{ PYTHON }} -m pip install . -vv
+  skip: true  # [py<39]
 
 requirements:
   host:
-    - python >=3.6.1,<4.0
+    - python
+    - pdm-backend
     - pip
-    - poetry-core
   run:
-    - python >=3.6.1,<4.0
-    - sqlalchemy >=1.4.17,<=1.4.41
-    - pydantic >=1.8.2,<2.0.0
-    - sqlalchemy2-stubs
+    - python
+    - sqlalchemy >=2.0.14,<2.1.0
+    - pydantic >=1.10.13,<3.0.0
 
 test:
   imports:
     - sqlmodel
-    - sqlmodel.engine
   commands:
     - pip check
     # Extract the version of the built package

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,14 +30,7 @@ test:
     - sqlmodel
   commands:
     - pip check
-    # Extract the version of the built package
-    - VERSION=$(python -c 'from importlib import metadata; print(metadata.version("sqlmodel"))')  # [not win]
-    - echo "sqlmodel version $VERSION"  # [not win]
-    # Ensure that version is not 0. (This conditional looks redundant, but YAML thinks
-     # that [...] denotes a list.)
-    - if [ "0" == "$VERSION" ]; then false; fi  # [not win]
-    # Windows version check
-    - python -c "from importlib import metadata; v = metadata.version('sqlmodel'); print(f'sqlmodel version {v}'); assert v != '0'"  # [win]
+    - python -c "from importlib import metadata; v = metadata.version('sqlmodel'); print(f'sqlmodel version {v}'); assert v != '0'"
   requires:
     - pip
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -59,3 +59,4 @@ extra:
     - tiangolo
     - maresb
     - thewchan
+ 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,11 +31,11 @@ test:
   commands:
     - pip check
     # Extract the version of the built package
-    - VERSION=$(python -c 'from importlib import metadata; print(metadata.version("sqlmodel"))')
-    - echo "sqlmodel version $VERSION"
+    - VERSION=$(python -c 'from importlib import metadata; print(metadata.version("sqlmodel"))') # [not win]
+    - echo "sqlmodel version $VERSION"  # [not win]
     # Ensure that version is not 0. (This conditional looks redundant, but YAML thinks
     # that [...] denotes a list.)
-    - if [ "0" == "$VERSION" ]; then false; fi
+    - if [ "0" == "$VERSION" ]; then false; fi  # [not win]
   requires:
     - pip
 
@@ -59,4 +59,3 @@ extra:
     - tiangolo
     - maresb
     - thewchan
- 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,6 +44,7 @@ about:
   summary: SQL databases in Python, designed for simplicity, compatibility, and robustness.
   doc_url: https://sqlmodel.tiangolo.com/
   license: MIT
+  license_family: MIT
   license_file: LICENSE
   description: |
     SQLModel is designed to simplify interacting with SQL databases in FastAPI
@@ -53,6 +54,7 @@ about:
      the best developer experience possible. SQLModel is, in fact, a thin layer
      on top of Pydantic and SQLAlchemy, carefully designed to be compatible with
      both.
+  dev_url: https://github.com/tiangolo/sqlmodel
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
 build:
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
-  skip: true  # [py<39]
+  skip: true  # [py<38]
 
 requirements:
   host:


### PR DESCRIPTION
## ☆ sqlmodel 0.0.24 ☆
[Jira Ticket](https://anaconda.atlassian.net/browse/PKG-8348) 
[Upstream](https://github.com/tiangolo/sqlmodel)

### Changes
* Updated `sqlmodel` from 0.0.8 to 0.0.24
* Simplified build process using `pdm-backend`
* Added platform-specific test commands for `Windows` compatibility
* Added additional information for `license_family` and `dev_url` to the `about` section